### PR TITLE
Adds a basic Docker setup needed for a standard Rails app on PG

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Slim is currently the preferred Rails View template gem.
 
 ## Docker
 
-TODO: Maybe?
+The template provides Docker setup as an option.  When this is selected bundler and the generators will be skipped so they can be run directly on the Docker container after running `docker-compose up`.

--- a/lib/template.rb
+++ b/lib/template.rb
@@ -5,11 +5,13 @@ templates_root = File.expand_path(File.join('..', 'templates'), File.dirname(__F
 source_paths << templates_root
 
 module RMSTemplate
-  RUBY_VERSION = '2.3.0'.freeze
+  RUBY_VERSION = '2.3.1'.freeze
   FILES = %w(
     .rubocop.yml
     Gemfile.tt
     .ruby-version.tt
+    docker-compose.yml.tt
+    Dockerfile.tt
   )
 end
 
@@ -25,8 +27,12 @@ end
 
 # Set up test frameworks
 after_bundle do
-  generate 'rspec:install'
-  generate 'spinach'
+  if @use_docker
+    puts 'Cannot automatically run generators with Docker'
+  else
+    generate 'rspec:install'
+    generate 'spinach'
+  end
 end
 
 # Set up Git Repo, if desired
@@ -43,6 +49,13 @@ RMSTemplate::FILES.each do |filename|
   template(filename, force: force_our_files)
 end
 
+if (@use_docker = yes?('Set up Docker?'))
+  def run_bundle
+    # Want to run bundler in the Docker container rather local system
+    # However we need a stub Gemfile.lock for the container to pickup
+    file 'Gemfile.lock', ''
+  end
+end
 
 # Since we have a .ruby-version file being added ... if we don't match,
 # bundle install will fail (or install on the wrong Ruby version). So

--- a/templates/Dockerfile.tt
+++ b/templates/Dockerfile.tt
@@ -1,0 +1,39 @@
+# Use the barebones version of Ruby <%= RMSTemplate::RUBY_VERSION %>.
+FROM ruby:<%= RMSTemplate::RUBY_VERSION %>-slim
+
+MAINTAINER Caleb Woods <caleb.woods@rolemodelsoftware.com>
+
+# Install dependencies:
+# - build-essential: To ensure certain gems can be compiled
+# - nodejs: Compile assets
+# - libpq-dev: Communicate with postgres through the postgres gem
+# - libsqlite3-dev: For mailcatcher
+RUN apt-get update && apt-get install -qq -y build-essential nodejs libpq-dev libsqlite3-dev --fix-missing --no-install-recommends
+
+# Set an environment variable to store where the app is installed to inside
+# of the Docker image.
+ENV INSTALL_PATH /<%= @app_name %>
+RUN mkdir -p $INSTALL_PATH
+
+# This sets the context of where commands will be ran in and is documented
+# on Docker's website extensively.
+WORKDIR $INSTALL_PATH
+
+# Ensure gems are cached and only get updated when they change. This will
+# drastically increase build times when your gems do not change.
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+RUN gem install bundler && bundle install --jobs 4 --retry 3
+
+# Copy in the application code from your work station at the current directory
+# over to the working directory.
+COPY . .
+
+# Provide dummy data to Rails so it can pre-compile assets.
+RUN bundle exec rake RAILS_ENV=production DATABASE_URL=postgresql://user:pass@127.0.0.1/dbname SECRET_TOKEN=pickasecuretoken assets:precompile
+
+# Expose a volume so that nginx will be able to read in assets in production.
+VOLUME ["$INSTALL_PATH/public"]
+
+# The default command that gets ran will be to start the server.
+CMD bundle exec rails server --port $PORT --binding 0.0.0.0

--- a/templates/Gemfile.tt
+++ b/templates/Gemfile.tt
@@ -14,6 +14,8 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
+# Turbolinks gem, may be removed if not needed
+gem 'turbolinks'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 

--- a/templates/docker-compose.yml.tt
+++ b/templates/docker-compose.yml.tt
@@ -1,0 +1,23 @@
+postgres:
+  image: postgres:9.5
+  environment:
+    POSTGRES_USER: <%= @app_name %>
+    POSTGRES_PASSWORD: <%= @app_name %>
+    POSTGRES_DB: <%= @app_name %>_development
+  ports:
+    - '5433:5432'
+  volumes:
+    - <%= @app_name %>-postgres:/var/lib/postgresql/data
+
+web:
+  build: .
+  links:
+    - postgres
+  volumes:
+    - .:/<%= @app_name %>
+  ports:
+    - '3000:3000'
+  environment:
+    - PORT=3000
+    - DATABASE_URL=postgresql://<%= @app_name %>:<%= @app_name %>@postgres:5432/<%= @app_name %>_development?encoding=utf8&pool=5&timeout=5000
+    - TEST_DATABASE_URL=postgresql://<%= @app_name %>:<%= @app_name %>@postgres:5432/<%= @app_name %>_test?encoding=utf8&pool=5&timeout=5000


### PR DESCRIPTION
Tested by generating a Sample app and then booting with Docker.

```
$ rails new sample -m Rails-Template/lib/template.rb
$ cd sample
$ docker-compose up
```

If we are going to have a README template some of the standard Docker language could be added there.

There is are also some "hacks" in this approach as I was trying to prevent action from being run on the host machine.  Open to suggestions or other approaches.

I also don't know what we should set for our standard MAINTAINER in our Dockerfiles
