### PR TITLE
Rubocop, SCSSLint, ESLint

### DIFF
--- a/lib/template.rb
+++ b/lib/template.rb
@@ -7,13 +7,16 @@ source_paths << templates_root
 module RMSTemplate
   RUBY_VERSION = '2.3.1'.freeze
   FILES = %w(
-    .rubocop.yml
     README.md.tt
     Gemfile.tt
     .ruby-version.tt
     docker-compose.yml.tt
     Dockerfile.tt
-  )
+    .rubocop.yml
+    .eslintignore
+    .eslintrc.js
+    lib/tasks/lint.rake.tt
+  ).freeze
 end
 
 force_our_files = yes?('Automatically overwrite default Rails files?')
@@ -45,10 +48,18 @@ if yes?('Set up Git Repo?')
   end
 end
 
+# Set up Linter tasks
+@fail_linter_builds = yes?('Should CI fail builds when Linters have errors?')
+
 # Source all our template files, force if desired
 RMSTemplate::FILES.each do |filename|
   template(filename, force: force_our_files)
 end
+
+append_to_file '.gitignore', <<-IGNORERUBOCOP.strip_heredoc
+  # Ignore Rubocop's local copy of our shared Rubocop config
+  .rubocop-https*
+IGNORERUBOCOP
 
 if (@use_docker = yes?('Set up Docker?'))
   def run_bundle

--- a/templates/.eslintignore
+++ b/templates/.eslintignore
@@ -1,0 +1,8 @@
+Gemfile*
+Procfile
+*.md
+Rakefile
+*.json
+node_modules/
+bower_components/
+*.sh

--- a/templates/.eslintrc.js
+++ b/templates/.eslintrc.js
@@ -1,0 +1,124 @@
+module.exports = {
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "node": true,
+    "jasmine": true,
+    "es6": true
+  },
+  "extends": "eslint:recommended",
+  "rules": {
+    "accessor-pairs": "warn",
+    "arrow-body-style": "warn",
+    "arrow-parens": "warn",
+    "arrow-spacing": "warn",
+    "comma-dangle": [
+      "warn",
+      "only-multiline"
+    ],
+    "comma-style": [
+      "warn",
+      "last"
+    ],
+    "computed-property-spacing": [
+      "warn",
+      "never"
+    ],
+    "consistent-this": "warn",
+    "curly": [
+      "warn",
+      "multi-line"
+    ],
+    "default-case": "warn",
+    "dot-location": [
+      "warn",
+      "property"
+    ],
+    "generator-star-spacing": "warn",
+    "id-blacklist": "warn",
+    "id-match": "warn",
+    "jsx-quotes": "warn",
+    "linebreak-style": [
+      "warn",
+      "unix"
+    ],
+    "max-nested-callbacks": "warn",
+    "no-array-constructor": "warn",
+    "no-caller": "warn",
+    "no-catch-shadow": "warn",
+    "no-confusing-arrow": "warn",
+    "no-console": "off",
+    "no-continue": "warn",
+    "no-div-regex": "warn",
+    "no-duplicate-imports": "warn",
+    "no-extra-label": "warn",
+    "no-extra-semi": "warn",
+    "no-floating-decimal": "warn",
+    "no-implicit-coercion": [
+      "warn",
+      {
+        "boolean": false,
+        "number": false,
+        "string": false
+      }
+    ],
+    "no-implied-eval": "warn",
+    "no-inner-declarations": [
+      "warn",
+      "functions"
+    ],
+    "no-invalid-this": "warn",
+    "no-iterator": "warn",
+    "no-label-var": "warn",
+    "no-labels": "warn",
+    "no-lone-blocks": "warn",
+    "no-mixed-requires": "warn",
+    "no-mixed-spaces-and-tabs": "warn",
+    "no-multi-str": "warn",
+    "no-new": "warn",
+    "no-new-func": "warn",
+    "no-new-object": "warn",
+    "no-new-require": "warn",
+    "no-new-wrappers": "warn",
+    "no-octal-escape": "warn",
+    "no-process-exit": "warn",
+    "no-proto": "warn",
+    "no-redeclare": "warn",
+    "no-restricted-globals": "warn",
+    "no-restricted-imports": "warn",
+    "no-restricted-modules": "warn",
+    "no-restricted-syntax": "warn",
+    "no-script-url": "warn",
+    "no-self-compare": "warn",
+    "no-shadow-restricted-names": "warn",
+    "no-spaced-func": "warn",
+    "no-undef": "warn",
+    "no-undef-init": "warn",
+    "no-unmodified-loop-condition": "warn",
+    "no-unneeded-ternary": [
+      "warn",
+      {
+        "defaultAssignment": true
+      }
+    ],
+    "no-unreachable": "warn",
+    "no-unused-vars": "warn",
+    "no-useless-call": "warn",
+    "no-useless-concat": "warn",
+    "no-useless-constructor": "warn",
+    "no-useless-escape": "warn",
+    "no-void": "warn",
+    "no-whitespace-before-property": "warn",
+    "no-with": "warn",
+    "prefer-const": "warn",
+    "require-yield": "warn",
+    "sort-imports": "warn",
+    "template-curly-spacing": "warn",
+    "wrap-regex": "warn",
+    "yield-star-spacing": "warn",
+    "yoda": [
+      "warn",
+      "never"
+    ]
+  }
+};

--- a/templates/Gemfile.tt
+++ b/templates/Gemfile.tt
@@ -58,8 +58,13 @@ group :development, :test do
   gem 'better_errors'
   # Silence JS / CSS lines from Rails' Server logging in Development mode
   gem 'quiet_assets'
-  # Linter for better Ruby code quality; see rubycop.yml
-  gem 'rubocop'
+  # Linter for better Ruby code quality; see .rubocop.yml
+  gem 'rubocop', require: false
+  # Linter for better JS code quality; see .eslintrc
+  gem 'eslint-rails'
+  # Linter for better CSS code quality;
+  # see https://github.com/brigade/scss-lint/blob/master/config/default.yml
+  gem 'scss_lint', require: false
   # Audit Ruby code for security issues
   gem 'brakeman'
   # Audit gems for security issues

--- a/templates/lib/tasks/lint.rake.tt
+++ b/templates/lib/tasks/lint.rake.tt
@@ -3,13 +3,30 @@ require 'bundler/audit/task'
 require 'scss_lint/rake_task'
 
 desc 'Run all linters against the project'
-task lint: %w(bundle:audit rubocop scss_lint eslint:run)
-
-Bundler::Audit::Task.new
+task :lint do
+  # Since only some linters can be configured to fail silently (passing exit
+  # code), we need to manually invoke all tasks and rescue their exit status.
+  # Passing linters will not show in the summary output.
+  exit_codes = {}
+  %w(bundle:audit rubocop scss_lint eslint:run).map do |task_name|
+    begin
+      Rake::Task[task_name].invoke
+    rescue SystemExit => ex
+      exit_codes[task_name] = ex.status
+    end
+  end
+  exit_codes.each do |task_name, exit_code|
+    puts "* #{task_name.titleize} exited with status code #{exit_code}"
+  end
+  <%- if @fail_linter_builds -%>
+  # Exit with a failing status code
+  abort if exit_codes.any?
+  <%- end -%>
+end
 
 RuboCop::RakeTask.new(:rubocop) do |task|
   task.fail_on_error = <%= @fail_linter_builds %>
 end
-<%# TODO: We can make it quiet, which means no output, but not 'pass anyway'? %>
+
 SCSSLint::RakeTask.new
-<%# TODO: Would be nice if we could config ESLint... %>
+<%# TODO: Would be nice if we could config ESLint... -%>

--- a/templates/lib/tasks/lint.rake.tt
+++ b/templates/lib/tasks/lint.rake.tt
@@ -1,0 +1,15 @@
+require 'rubocop/rake_task'
+require 'bundler/audit/task'
+require 'scss_lint/rake_task'
+
+desc 'Run all linters against the project'
+task lint: %w(bundle:audit rubocop scss_lint eslint:run)
+
+Bundler::Audit::Task.new
+
+RuboCop::RakeTask.new(:rubocop) do |task|
+  task.fail_on_error = <%= @fail_linter_builds %>
+end
+<%# TODO: We can make it quiet, which means no output, but not 'pass anyway'? %>
+SCSSLint::RakeTask.new
+<%# TODO: Would be nice if we could config ESLint... %>


### PR DESCRIPTION
Adds ESLint and SCSS Lint gems.

Add a 'Lint' rake task, which runs Bundler-Audit, Rubocop, SCSS-Lint, and ESLint:
`bundle exec rake lint`

This _may_ fail a Semaphore build (unless you run it as `bundle exec rake lint || echo 'Failures detected'`) at this time for:
- Bundler Audit
- Rubocop - Optional (template asks to fail build or not)
- SCSS Lint
- ESLint
